### PR TITLE
fix: updated personalize cookie name

### DIFF
--- a/examples/nextjs/components/Cloudsdk.ts
+++ b/examples/nextjs/components/Cloudsdk.ts
@@ -22,7 +22,7 @@ export function CloudSDKComponent() {
     })
       .addEvents()
       .addSearch()
-      .addPersonalize({ webPersonalization: { language: 'en' } })
+      .addPersonalize({ enablePersonalizeCookie: true, webPersonalization: { language: 'en' } })
       .initialize();
   }, []);
 

--- a/packages/personalize/src/lib/initializer/browser/initializer.spec.ts
+++ b/packages/personalize/src/lib/initializer/browser/initializer.spec.ts
@@ -188,7 +188,7 @@ describe('addPersonalize', () => {
     expect(PackageInitializer).toHaveBeenCalledWith({
       dependencies: [],
       settings: {
-        cookieSettings: { name: { guestId: 'sc_undefined_personalize' } },
+        cookieSettings: { name: { guestId: 'sc_rid_personalize' } },
         enablePersonalizeCookie: false,
         webPersonalization: false
       },
@@ -206,7 +206,7 @@ describe('addPersonalize', () => {
     expect(PackageInitializer).toHaveBeenCalledWith({
       dependencies: [],
       settings: {
-        cookieSettings: { name: { guestId: 'sc_undefined_personalize' } },
+        cookieSettings: { name: { guestId: 'sc_rid_personalize' } },
         enablePersonalizeCookie: false,
         webPersonalization: false
       },
@@ -224,7 +224,7 @@ describe('addPersonalize', () => {
     expect(PackageInitializer).toHaveBeenCalledWith({
       dependencies: [{ method: 'addEvents', name: '@sitecore-cloudsdk/events' }],
       settings: {
-        cookieSettings: { name: { guestId: 'sc_undefined_personalize' } },
+        cookieSettings: { name: { guestId: 'sc_rid_personalize' } },
         enablePersonalizeCookie: true,
         webPersonalization: { async: true, defer: false }
       },
@@ -241,7 +241,7 @@ describe('addPersonalize', () => {
     expect(PackageInitializer).toHaveBeenCalledWith({
       dependencies: [{ method: 'addEvents', name: '@sitecore-cloudsdk/events' }],
       settings: {
-        cookieSettings: { name: { guestId: 'sc_undefined_personalize' } },
+        cookieSettings: { name: { guestId: 'sc_rid_personalize' } },
         webPersonalization: { async: true, defer: true }
       },
       sideEffects
@@ -257,7 +257,7 @@ describe('addPersonalize', () => {
     expect(PackageInitializer).toHaveBeenCalledWith({
       dependencies: [{ method: 'addEvents', name: '@sitecore-cloudsdk/events' }],
       settings: {
-        cookieSettings: { name: { guestId: 'sc_undefined_personalize' } },
+        cookieSettings: { name: { guestId: 'sc_rid_personalize' } },
         webPersonalization: { async: false, defer: false }
       },
       sideEffects
@@ -272,7 +272,7 @@ describe('addPersonalize', () => {
     expect(PackageInitializer).toHaveBeenCalledWith({
       dependencies: [{ method: 'addEvents', name: '@sitecore-cloudsdk/events' }],
       settings: {
-        cookieSettings: { name: { guestId: 'sc_undefined_personalize' } },
+        cookieSettings: { name: { guestId: 'sc_rid_personalize' } },
         webPersonalization: { async: false, defer: true }
       },
       sideEffects
@@ -287,7 +287,7 @@ describe('addPersonalize', () => {
     expect(PackageInitializer).toHaveBeenCalledWith({
       dependencies: [{ method: 'addEvents', name: '@sitecore-cloudsdk/events' }],
       settings: {
-        cookieSettings: { name: { guestId: 'sc_undefined_personalize' } },
+        cookieSettings: { name: { guestId: 'sc_rid_personalize' } },
         webPersonalization: { async: true, defer: false }
       },
       sideEffects

--- a/packages/personalize/src/lib/initializer/browser/initializer.ts
+++ b/packages/personalize/src/lib/initializer/browser/initializer.ts
@@ -1,6 +1,7 @@
 // © Sitecore Corporation A/S. All rights reserved. Sitecore® is a registered trademark of Sitecore Corporation A/S.
 import { CloudSDKBrowserInitializer } from '@sitecore-cloudsdk/core/browser';
 import {
+  BROWSER_ID_COOKIE_NAME,
   COOKIE_NAME_PREFIX,
   debug,
   enabledPackagesBrowser as enabledPackages,
@@ -58,7 +59,7 @@ export function addPersonalize(
 
   const cookieSettings = {
     name: {
-      guestId: `${COOKIE_NAME_PREFIX}${getCloudSDKSettings().sitecoreEdgeContextId}_personalize`
+      guestId: `${COOKIE_NAME_PREFIX}${BROWSER_ID_COOKIE_NAME}_personalize`
     }
   };
 

--- a/packages/personalize/src/lib/initializer/server/initializer.spec.ts
+++ b/packages/personalize/src/lib/initializer/server/initializer.spec.ts
@@ -88,7 +88,7 @@ describe('addPersonalize', () => {
     expect(PackageInitializerServer).toHaveBeenCalledTimes(1);
     expect(PackageInitializerServer).toHaveBeenCalledWith({
       settings: {
-        cookieSettings: { name: { guestId: 'sc_undefined_personalize' } },
+        cookieSettings: { name: { guestId: 'sc_rid_personalize' } },
         enablePersonalizeCookie: false
       },
       sideEffects: initializerModule.sideEffects

--- a/packages/personalize/src/lib/initializer/server/initializer.ts
+++ b/packages/personalize/src/lib/initializer/server/initializer.ts
@@ -1,5 +1,6 @@
 // © Sitecore Corporation A/S. All rights reserved. Sitecore® is a registered trademark of Sitecore Corporation A/S.
 import {
+  BROWSER_ID_COOKIE_NAME,
   COOKIE_NAME_PREFIX,
   debug,
   enabledPackagesServer as enabledPackages,
@@ -36,7 +37,7 @@ export function addPersonalize(
 ): CloudSDKServerInitializer {
   const cookieSettings = {
     name: {
-      guestId: `${COOKIE_NAME_PREFIX}${getCloudSDKSettingsServer().sitecoreEdgeContextId}_personalize`
+      guestId: `${COOKIE_NAME_PREFIX}${BROWSER_ID_COOKIE_NAME}_personalize`
     }
   };
 


### PR DESCRIPTION
## 📌 Description

Renamed personalize cookie, now it should be called `sc_rid_personalize`

### 🔍 Related issues

N/a

### 📦Affected Packages

<!-- Mark one or more of the following list
-->

- [ ] Utils
- [ ] Core
- [ ] Events
- [x] Personalize
- [ ] Search
- [ ] Examples/nextjs app
- [ ] Github Workflows
- [ ] Others

## ⤵️ Dependencies Introduced
n/a

## 📸 Screenshots

n/a

## 💬 Additional Notes

n/a
