### PR TITLE
fix: reverted cookie rename

### DIFF
--- a/packages/core/src/internal.ts
+++ b/packages/core/src/internal.ts
@@ -10,7 +10,6 @@ export { debug, processDebugResponse } from './lib/debug/debug';
 export {
   API_VERSION,
   COOKIE_NAME_PREFIX,
-  BROWSER_ID_COOKIE_NAME,
   DAILY_SECONDS,
   DEFAULT_COOKIE_EXPIRY_DAYS,
   LIBRARY_VERSION,

--- a/packages/core/src/lib/consts.ts
+++ b/packages/core/src/lib/consts.ts
@@ -7,8 +7,6 @@ export const LIBRARY_VERSION = packageJson.version;
 
 export const COOKIE_NAME_PREFIX = 'sc_';
 
-export const BROWSER_ID_COOKIE_NAME = 'rid';
-
 export const DEFAULT_COOKIE_EXPIRY_DAYS = 730;
 
 export const DAILY_SECONDS = 86400;

--- a/packages/core/src/lib/initializer/browser/initializer.spec.ts
+++ b/packages/core/src/lib/initializer/browser/initializer.spec.ts
@@ -2,7 +2,6 @@ import debug from 'debug';
 import * as utils from '@sitecore-cloudsdk/utils';
 import * as fetchBrowserIdFromEdgeProxy from '../../browser-id/fetch-browser-id-from-edge-proxy';
 import {
-  BROWSER_ID_COOKIE_NAME,
   COOKIE_NAME_PREFIX,
   DEFAULT_COOKIE_EXPIRY_DAYS,
   ErrorMessages,
@@ -46,7 +45,7 @@ const mockSettingsParamsInternal: Settings = {
     domain: 'cDomain',
     enableBrowserCookie: true,
     expiryDays: 730,
-    name: { browserId: `${COOKIE_NAME_PREFIX}${BROWSER_ID_COOKIE_NAME}` },
+    name: { browserId: `${COOKIE_NAME_PREFIX}123` },
     path: '/'
   },
   siteName: '456',
@@ -132,7 +131,7 @@ describe('initializer browser', () => {
       expect(result.cookieSettings.enableBrowserCookie).toBe(false);
       expect(result.cookieSettings.expiryDays).toBe(DEFAULT_COOKIE_EXPIRY_DAYS);
       expect(result.cookieSettings.path).toBe('/');
-      expect(result.cookieSettings.name.browserId).toBe(`${COOKIE_NAME_PREFIX}${BROWSER_ID_COOKIE_NAME}`);
+      expect(result.cookieSettings.name.browserId).toBe(`${COOKIE_NAME_PREFIX}123`);
       expect(result.sitecoreEdgeUrl).toBe(SITECORE_EDGE_URL);
     });
   });
@@ -246,7 +245,7 @@ describe('initializer browser', () => {
       mockSettingsParamsPublic.enableBrowserCookie = true;
 
       const debugMock = debug as unknown as jest.Mock;
-      const expectedBrowserIdCookieName = `${COOKIE_NAME_PREFIX}${BROWSER_ID_COOKIE_NAME}`;
+      const expectedBrowserIdCookieName = `${COOKIE_NAME_PREFIX}123`;
       const expectedBrowserIdValue = 'bid_value';
 
       jest.spyOn(getDefaultCookieAttributes, 'getDefaultCookieAttributes').mockReturnValueOnce(mockCookieAttributes);
@@ -272,7 +271,7 @@ describe('initializer browser', () => {
     it(`should NOT call 'debug' third-party lib with 'sitecore-cloudsdk:core' as a namespace 
       when there are enabledPackages`, async () => {
       const debugMock = debug as unknown as jest.Mock;
-      const expectedBrowserIdCookieName = `${COOKIE_NAME_PREFIX}${BROWSER_ID_COOKIE_NAME}`;
+      const expectedBrowserIdCookieName = `${COOKIE_NAME_PREFIX}123`;
       const expectedBrowserIdValue = 'bid_value';
 
       const getDefaultCookieAttributesSpy = jest
@@ -304,7 +303,7 @@ describe('initializer browser', () => {
     });
 
     it('should create the cookie and add it to document.cookie', async () => {
-      const expectedBrowserIdCookieName = `${COOKIE_NAME_PREFIX}${BROWSER_ID_COOKIE_NAME}`;
+      const expectedBrowserIdCookieName = `${COOKIE_NAME_PREFIX}123`;
       const expectedBrowserIdValue = 'bid_value';
 
       const getDefaultCookieAttributesSpy = jest
@@ -339,7 +338,7 @@ describe('initializer browser', () => {
     it(`should not create a browserId cookie if cookieName exists`, async () => {
       const getCookieSpy = jest
         .spyOn(utils, 'getCookie')
-        .mockReturnValueOnce({ name: `${COOKIE_NAME_PREFIX}${BROWSER_ID_COOKIE_NAME}`, value: 'bid_value' });
+        .mockReturnValueOnce({ name: `${COOKIE_NAME_PREFIX}123`, value: 'bid_value' });
 
       const fetchBrowserIdFromEdgeProxySpy = jest
         .spyOn(fetchBrowserIdFromEdgeProxy, 'fetchBrowserIdFromEdgeProxy')

--- a/packages/core/src/lib/initializer/browser/initializer.ts
+++ b/packages/core/src/lib/initializer/browser/initializer.ts
@@ -3,7 +3,6 @@ import { createCookieString, getCookie } from '@sitecore-cloudsdk/utils';
 import { fetchBrowserIdFromEdgeProxy } from '../../browser-id/fetch-browser-id-from-edge-proxy';
 import { getBrowserId } from '../../browser-id/get-browser-id';
 import {
-  BROWSER_ID_COOKIE_NAME,
   COOKIE_NAME_PREFIX,
   DEFAULT_COOKIE_EXPIRY_DAYS,
   ErrorMessages,
@@ -114,7 +113,7 @@ export class CloudSDKBrowserInitializer {
         enableBrowserCookie: enableBrowserCookie ?? false,
         expiryDays: cookieExpiryDays || DEFAULT_COOKIE_EXPIRY_DAYS,
         name: {
-          browserId: `${COOKIE_NAME_PREFIX}${BROWSER_ID_COOKIE_NAME}`
+          browserId: `${COOKIE_NAME_PREFIX}${sitecoreEdgeContextId}`
         },
         path: cookiePath || '/'
       },

--- a/packages/core/src/lib/initializer/server/initializer.spec.ts
+++ b/packages/core/src/lib/initializer/server/initializer.spec.ts
@@ -1,13 +1,7 @@
 import debug from 'debug';
 import * as utils from '@sitecore-cloudsdk/utils';
 import * as fetchBrowserIdFromEdgeProxy from '../../browser-id/fetch-browser-id-from-edge-proxy';
-import {
-  BROWSER_ID_COOKIE_NAME,
-  COOKIE_NAME_PREFIX,
-  DEFAULT_COOKIE_EXPIRY_DAYS,
-  ErrorMessages,
-  SITECORE_EDGE_URL
-} from '../../consts';
+import { COOKIE_NAME_PREFIX, DEFAULT_COOKIE_EXPIRY_DAYS, ErrorMessages, SITECORE_EDGE_URL } from '../../consts';
 import * as getCookieValueFromMiddlewareRequestModule from '../../cookie/get-cookie-value-from-middleware-request';
 import * as getDefaultCookieAttributes from '../../cookie/get-default-cookie-attributes';
 import { CORE_NAMESPACE } from '../../debug/namespaces';
@@ -50,7 +44,7 @@ describe('initializer server', () => {
       domain: 'cDomain',
       enableServerCookie: true,
       expiryDays: 730,
-      name: { browserId: `${COOKIE_NAME_PREFIX}${BROWSER_ID_COOKIE_NAME}` },
+      name: { browserId: `${COOKIE_NAME_PREFIX}123` },
       path: '/'
     },
     siteName: '456',
@@ -83,7 +77,7 @@ describe('initializer server', () => {
       expect(result.cookieSettings.enableServerCookie).toBe(false);
       expect(result.cookieSettings.expiryDays).toBe(DEFAULT_COOKIE_EXPIRY_DAYS);
       expect(result.cookieSettings.path).toBe('/');
-      expect(result.cookieSettings.name.browserId).toBe(`${COOKIE_NAME_PREFIX}${BROWSER_ID_COOKIE_NAME}`);
+      expect(result.cookieSettings.name.browserId).toBe(`${COOKIE_NAME_PREFIX}123`);
       expect(result.sitecoreEdgeUrl).toBe(SITECORE_EDGE_URL);
     });
   });
@@ -239,7 +233,7 @@ describe('initializer server', () => {
 
       it(`should handle the browser ID cookie in the request and response when the cookie is present`, async () => {
         mockSettingsParamsPublic.enableServerCookie = true;
-        const browserIdCookieName = 'sc_rid';
+        const browserIdCookieName = 'sc_123';
 
         getCookieValueFromMiddlewareRequestSpy.mockReturnValueOnce('browser_id_from_proxy');
         isNextJsMiddlewareRequestSpy.mockReturnValueOnce(true);
@@ -261,7 +255,7 @@ describe('initializer server', () => {
         const fetchBrowserIdFromEdgeProxySpy = jest.spyOn(fetchBrowserIdFromEdgeProxy, 'fetchBrowserIdFromEdgeProxy');
         global.fetch = jest.fn().mockImplementationOnce(() => mockFetch);
 
-        const mockBrowserIdCookie = { name: 'sc_rid', value: 'browser_id_from_proxy' };
+        const mockBrowserIdCookie = { name: 'sc_123', value: 'browser_id_from_proxy' };
 
         await new initializerModule.CloudSDKServerInitializer(request, response, mockSettingsParamsPublic).initialize();
 
@@ -294,7 +288,7 @@ describe('initializer server', () => {
       });
 
       it(`should handle the browser ID cookie in the request and response when the cookie is present`, async () => {
-        const mockBrowserIdCookie = { name: 'sc_rid', value: '123456789' };
+        const mockBrowserIdCookie = { name: 'sc_123', value: '123456789' };
 
         isNextJsMiddlewareRequestSpy.mockReturnValueOnce(false);
         isNextJsMiddlewareResponseSpy.mockReturnValueOnce(false);
@@ -306,7 +300,7 @@ describe('initializer server', () => {
 
         await new initializerModule.CloudSDKServerInitializer(request, response, mockSettingsParamsPublic).initialize();
 
-        expect(createCookieStringSpy).toHaveBeenNthCalledWith(1, 'sc_rid', '123456789', { test: true });
+        expect(createCookieStringSpy).toHaveBeenNthCalledWith(1, 'sc_123', '123456789', { test: true });
 
         expect(request.headers.cookie).toBe('sc_rid=123456789');
         expect(response.setHeader).toHaveBeenCalledWith('Set-Cookie', 'sc_rid=123456789');
@@ -336,16 +330,16 @@ describe('initializer server', () => {
         jest.spyOn(utils, 'getCookieServerSide').mockReturnValueOnce(undefined).mockReturnValueOnce(undefined);
         const createCookieStringSpy = jest
           .spyOn(utils, 'createCookieString')
-          .mockReturnValueOnce('sc_rid=browser_id_from_proxy');
+          .mockReturnValueOnce('sc_123=browser_id_from_proxy');
 
         await new initializerModule.CloudSDKServerInitializer(request, response, mockSettingsParamsPublic).initialize();
 
-        expect(createCookieStringSpy).toHaveBeenNthCalledWith(1, 'sc_rid', 'browser_id_from_proxy', { test: true });
+        expect(createCookieStringSpy).toHaveBeenNthCalledWith(1, 'sc_123', 'browser_id_from_proxy', { test: true });
         expect(initializerModule.getCookiesValuesFromEdge()).toEqual({
           browserId: 'browser_id_from_proxy',
           guestId: 'guest_id_from_proxy'
         });
-        expect(request.headers.cookie).toBe('random=123456789; sc_rid=browser_id_from_proxy');
+        expect(request.headers.cookie).toBe('random=123456789; sc_123=browser_id_from_proxy');
       });
 
       it('should set cookie header directly when no existing cookie header exists', async () => {
@@ -374,7 +368,7 @@ describe('initializer server', () => {
 
         await new initializerModule.CloudSDKServerInitializer(request, response, mockSettingsParamsPublic).initialize();
 
-        expect(createCookieStringSpy).toHaveBeenNthCalledWith(1, 'sc_rid', 'browser_id_from_proxy', { test: true });
+        expect(createCookieStringSpy).toHaveBeenNthCalledWith(1, 'sc_123', 'browser_id_from_proxy', { test: true });
         expect(initializerModule.getCookiesValuesFromEdge()).toEqual({
           browserId: 'browser_id_from_proxy',
           guestId: 'guest_id_from_proxy'
@@ -504,7 +498,7 @@ describe('getCloudSDKSettings', () => {
       domain: 'cDomain',
       enableServerCookie: true,
       expiryDays: 730,
-      name: { browserId: `${COOKIE_NAME_PREFIX}${BROWSER_ID_COOKIE_NAME}` },
+      name: { browserId: `${COOKIE_NAME_PREFIX}123` },
       path: '/'
     },
     siteName: '456',

--- a/packages/core/src/lib/initializer/server/initializer.ts
+++ b/packages/core/src/lib/initializer/server/initializer.ts
@@ -16,13 +16,7 @@ import {
   isNextJsMiddlewareResponse
 } from '@sitecore-cloudsdk/utils';
 import { fetchBrowserIdFromEdgeProxy } from '../../browser-id/fetch-browser-id-from-edge-proxy';
-import {
-  BROWSER_ID_COOKIE_NAME,
-  COOKIE_NAME_PREFIX,
-  DEFAULT_COOKIE_EXPIRY_DAYS,
-  ErrorMessages,
-  SITECORE_EDGE_URL
-} from '../../consts';
+import { COOKIE_NAME_PREFIX, DEFAULT_COOKIE_EXPIRY_DAYS, ErrorMessages, SITECORE_EDGE_URL } from '../../consts';
 import { getCookieValueFromMiddlewareRequest } from '../../cookie/get-cookie-value-from-middleware-request';
 import { getDefaultCookieAttributes } from '../../cookie/get-default-cookie-attributes';
 import { debug } from '../../debug/debug';
@@ -112,7 +106,7 @@ export class CloudSDKServerInitializer {
         enableServerCookie: enableServerCookie ?? false,
         expiryDays: cookieExpiryDays || DEFAULT_COOKIE_EXPIRY_DAYS,
         name: {
-          browserId: `${COOKIE_NAME_PREFIX}${BROWSER_ID_COOKIE_NAME}`
+          browserId: `${COOKIE_NAME_PREFIX}${sitecoreEdgeContextId}`
         },
         path: cookiePath || '/'
       },

--- a/packages/personalize/src/lib/initializer/browser/initializer.spec.ts
+++ b/packages/personalize/src/lib/initializer/browser/initializer.spec.ts
@@ -188,7 +188,7 @@ describe('addPersonalize', () => {
     expect(PackageInitializer).toHaveBeenCalledWith({
       dependencies: [],
       settings: {
-        cookieSettings: { name: { guestId: 'sc_rid_personalize' } },
+        cookieSettings: { name: { guestId: 'sc_undefined_personalize' } },
         enablePersonalizeCookie: false,
         webPersonalization: false
       },
@@ -206,7 +206,7 @@ describe('addPersonalize', () => {
     expect(PackageInitializer).toHaveBeenCalledWith({
       dependencies: [],
       settings: {
-        cookieSettings: { name: { guestId: 'sc_rid_personalize' } },
+        cookieSettings: { name: { guestId: 'sc_undefined_personalize' } },
         enablePersonalizeCookie: false,
         webPersonalization: false
       },
@@ -224,7 +224,7 @@ describe('addPersonalize', () => {
     expect(PackageInitializer).toHaveBeenCalledWith({
       dependencies: [{ method: 'addEvents', name: '@sitecore-cloudsdk/events' }],
       settings: {
-        cookieSettings: { name: { guestId: 'sc_rid_personalize' } },
+        cookieSettings: { name: { guestId: 'sc_undefined_personalize' } },
         enablePersonalizeCookie: true,
         webPersonalization: { async: true, defer: false }
       },
@@ -241,7 +241,7 @@ describe('addPersonalize', () => {
     expect(PackageInitializer).toHaveBeenCalledWith({
       dependencies: [{ method: 'addEvents', name: '@sitecore-cloudsdk/events' }],
       settings: {
-        cookieSettings: { name: { guestId: 'sc_rid_personalize' } },
+        cookieSettings: { name: { guestId: 'sc_undefined_personalize' } },
         webPersonalization: { async: true, defer: true }
       },
       sideEffects
@@ -257,7 +257,7 @@ describe('addPersonalize', () => {
     expect(PackageInitializer).toHaveBeenCalledWith({
       dependencies: [{ method: 'addEvents', name: '@sitecore-cloudsdk/events' }],
       settings: {
-        cookieSettings: { name: { guestId: 'sc_rid_personalize' } },
+        cookieSettings: { name: { guestId: 'sc_undefined_personalize' } },
         webPersonalization: { async: false, defer: false }
       },
       sideEffects
@@ -272,7 +272,7 @@ describe('addPersonalize', () => {
     expect(PackageInitializer).toHaveBeenCalledWith({
       dependencies: [{ method: 'addEvents', name: '@sitecore-cloudsdk/events' }],
       settings: {
-        cookieSettings: { name: { guestId: 'sc_rid_personalize' } },
+        cookieSettings: { name: { guestId: 'sc_undefined_personalize' } },
         webPersonalization: { async: false, defer: true }
       },
       sideEffects
@@ -287,7 +287,7 @@ describe('addPersonalize', () => {
     expect(PackageInitializer).toHaveBeenCalledWith({
       dependencies: [{ method: 'addEvents', name: '@sitecore-cloudsdk/events' }],
       settings: {
-        cookieSettings: { name: { guestId: 'sc_rid_personalize' } },
+        cookieSettings: { name: { guestId: 'sc_undefined_personalize' } },
         webPersonalization: { async: true, defer: false }
       },
       sideEffects

--- a/packages/personalize/src/lib/initializer/browser/initializer.ts
+++ b/packages/personalize/src/lib/initializer/browser/initializer.ts
@@ -1,7 +1,6 @@
 // © Sitecore Corporation A/S. All rights reserved. Sitecore® is a registered trademark of Sitecore Corporation A/S.
 import { CloudSDKBrowserInitializer } from '@sitecore-cloudsdk/core/browser';
 import {
-  BROWSER_ID_COOKIE_NAME,
   COOKIE_NAME_PREFIX,
   debug,
   enabledPackagesBrowser as enabledPackages,
@@ -59,7 +58,7 @@ export function addPersonalize(
 
   const cookieSettings = {
     name: {
-      guestId: `${COOKIE_NAME_PREFIX}${BROWSER_ID_COOKIE_NAME}_personalize`
+      guestId: `${COOKIE_NAME_PREFIX}${getCloudSDKSettings().sitecoreEdgeContextId}_personalize`
     }
   };
 

--- a/packages/personalize/src/lib/initializer/server/initializer.spec.ts
+++ b/packages/personalize/src/lib/initializer/server/initializer.spec.ts
@@ -88,7 +88,7 @@ describe('addPersonalize', () => {
     expect(PackageInitializerServer).toHaveBeenCalledTimes(1);
     expect(PackageInitializerServer).toHaveBeenCalledWith({
       settings: {
-        cookieSettings: { name: { guestId: 'sc_rid_personalize' } },
+        cookieSettings: { name: { guestId: 'sc_undefined_personalize' } },
         enablePersonalizeCookie: false
       },
       sideEffects: initializerModule.sideEffects

--- a/packages/personalize/src/lib/initializer/server/initializer.ts
+++ b/packages/personalize/src/lib/initializer/server/initializer.ts
@@ -1,6 +1,5 @@
 // © Sitecore Corporation A/S. All rights reserved. Sitecore® is a registered trademark of Sitecore Corporation A/S.
 import {
-  BROWSER_ID_COOKIE_NAME,
   COOKIE_NAME_PREFIX,
   debug,
   enabledPackagesServer as enabledPackages,
@@ -37,7 +36,7 @@ export function addPersonalize(
 ): CloudSDKServerInitializer {
   const cookieSettings = {
     name: {
-      guestId: `${COOKIE_NAME_PREFIX}${BROWSER_ID_COOKIE_NAME}_personalize`
+      guestId: `${COOKIE_NAME_PREFIX}${getCloudSDKSettingsServer().sitecoreEdgeContextId}_personalize`
     }
   };
 


### PR DESCRIPTION
## 📌 Description

Reverting back cookie rename.

### 🔍 Related issues

<!-- If any, add a link to an issue that describes this -->

### 📦Affected Packages

<!-- Mark one or more of the following list
-->

- [ ] Utils
- [x] Core
- [ ] Events
- [x] Personalize
- [ ] Search
- [ ] Examples/nextjs app
- [ ] Github Workflows
- [ ] Others

## ⤵️ Dependencies Introduced

<!-- If any, describe dependencies introduced and why
-->

## 📸 Screenshots

<!-- Add screenshots, recordings or code examples to illustrate your changes. -->

## 💬 Additional Notes

 <!-- Provide any other relevant information, like breaking changes or workarounds. -->
