### PR TITLE
fix: fixed relative imports on personalize

### DIFF
--- a/packages/core/src/internal.ts
+++ b/packages/core/src/internal.ts
@@ -10,6 +10,7 @@ export { debug, processDebugResponse } from './lib/debug/debug';
 export {
   API_VERSION,
   COOKIE_NAME_PREFIX,
+  BROWSER_ID_COOKIE_NAME,
   DAILY_SECONDS,
   DEFAULT_COOKIE_EXPIRY_DAYS,
   LIBRARY_VERSION,

--- a/packages/personalize/src/lib/initializer/browser/initializer.ts
+++ b/packages/personalize/src/lib/initializer/browser/initializer.ts
@@ -1,7 +1,7 @@
 // © Sitecore Corporation A/S. All rights reserved. Sitecore® is a registered trademark of Sitecore Corporation A/S.
-import { BROWSER_ID_COOKIE_NAME } from 'packages/core/src/lib/consts';
 import { CloudSDKBrowserInitializer } from '@sitecore-cloudsdk/core/browser';
 import {
+  BROWSER_ID_COOKIE_NAME,
   COOKIE_NAME_PREFIX,
   debug,
   enabledPackagesBrowser as enabledPackages,

--- a/packages/personalize/src/lib/initializer/server/initializer.ts
+++ b/packages/personalize/src/lib/initializer/server/initializer.ts
@@ -1,6 +1,6 @@
 // © Sitecore Corporation A/S. All rights reserved. Sitecore® is a registered trademark of Sitecore Corporation A/S.
-import { BROWSER_ID_COOKIE_NAME } from 'packages/core/src/lib/consts';
 import {
+  BROWSER_ID_COOKIE_NAME,
   COOKIE_NAME_PREFIX,
   debug,
   enabledPackagesServer as enabledPackages,


### PR DESCRIPTION
## 📌 Description

Fixed relative imports on personalize package.

### 🔍 Related issues

Personalize package: relative import of a constant

### 📦Affected Packages

<!-- Mark one or more of the following list
-->

- [ ] Utils
- [x] Core
- [ ] Events
- [x] Personalize
- [ ] Search
- [ ] Examples/nextjs app
- [ ] Github Workflows
- [ ] Others

## ⤵️ Dependencies Introduced

n/a

## 📸 Screenshots

n/a

## 💬 Additional Notes

n/a